### PR TITLE
Allow for creation of new data with a form field input

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM rust:1.50.0-alpine3.13 AS builder
 RUN adduser --disabled-password --no-create-home --uid 1000 notroot notroot
 
 # Perform apk actions as root
-RUN apk add --no-cache musl-dev=1.2.2-r0 openssl-dev=1.1.1k-r0 libsodium-dev=1.0.18-r0 make=4.3-r0
+RUN apk add --no-cache musl-dev=1.2.2-r1 openssl-dev=1.1.1k-r0 libsodium-dev=1.0.18-r0 make=4.3-r0
 
 # Create build directory as root
 WORKDIR /usr/src

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,7 +4,7 @@ FROM rust:1.50.0-alpine3.13 AS builder
 RUN adduser --disabled-password --no-create-home --uid 1000 service service
 
 # Perform apk actions as root
-RUN apk add --no-cache musl-dev=1.2.2-r0 openssl-dev=1.1.1k-r0 libsodium-dev=1.0.18-r0 make=4.3-r0
+RUN apk add --no-cache musl-dev=1.2.2-r1 openssl-dev=1.1.1k-r0 libsodium-dev=1.0.18-r0 make=4.3-r0
 
 # Create build directory as root
 WORKDIR /usr/src

--- a/src/render.rs
+++ b/src/render.rs
@@ -38,7 +38,7 @@ pub struct UnsecureTemplateValues {
     pub index: Option<i64>,
     pub fetch_id: Option<String>,
     pub create: Option<bool>,
-    pub create_data_type: Option<DataType>
+    pub data_type: Option<DataType>
 }
 
 #[derive(Serialize, Debug, Default, PartialEq)]

--- a/src/render.rs
+++ b/src/render.rs
@@ -2,7 +2,7 @@ use handlebars::{
     Context, Handlebars, Helper, Output, RenderContext, RenderError as HandlebarsRenderError,
     TemplateError as HandlebarsTemplateError,
 };
-use redact_data::{Data, DataValue, DataValueCollection, UnencryptedDataValue};
+use redact_data::{Data, DataValue, DataValueCollection, UnencryptedDataValue, DataType};
 use serde::Serialize;
 use std::ops::Deref;
 use std::{
@@ -37,6 +37,8 @@ pub struct UnsecureTemplateValues {
     pub edit: Option<bool>,
     pub index: Option<i64>,
     pub fetch_id: Option<String>,
+    pub create: Option<bool>,
+    pub create_data_type: Option<DataType>
 }
 
 #[derive(Serialize, Debug, Default, PartialEq)]

--- a/src/routes/data/get.rs
+++ b/src/routes/data/get.rs
@@ -23,7 +23,7 @@ struct WithoutTokenQueryParams {
     fetch_id: Option<String>,
     index: Option<i64>,
     create: Option<bool>,
-    create_data_type: Option<DataType>
+    data_type: Option<DataType>
 }
 
 #[derive(Deserialize, Serialize)]
@@ -38,7 +38,7 @@ struct WithTokenQueryParams {
     index: Option<i64>,
     fetch_id: Option<String>,
     create: Option<bool>,
-    create_data_type: Option<DataType>
+    data_type: Option<DataType>
 }
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -84,7 +84,7 @@ pub fn without_token<S: SessionStore, R: Renderer, T: TokenGenerator>(
                     index: query_params.index,
                     fetch_id: query_params.fetch_id,
                     create: query_params.create,
-                    create_data_type: query_params.create_data_type,
+                    data_type: query_params.data_type,
                 };
                 Ok::<_, Rejection>((
                     Rendered::new(
@@ -230,7 +230,7 @@ pub fn with_token<S: SessionStore, R: Renderer, T: TokenGenerator, D: DataStorer
                                     if create {
                                         Ok(Data::new(
                                             &path_params.path,
-                                            match query_params.create_data_type.clone() {
+                                            match query_params.data_type.clone() {
                                                 Some(DataType::String) => DataValue::Unencrypted(UnencryptedDataValue::String("".to_owned())),
                                                 Some(DataType::U64) => DataValue::Unencrypted(UnencryptedDataValue::U64(0)),
                                                 Some(DataType::I64) => DataValue::Unencrypted(UnencryptedDataValue::I64(0)),
@@ -524,7 +524,7 @@ mod tests {
 
             let res = warp::test::request()
                 .method("POST")
-                .path("/data/.testKey./E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9C?create=true&create_data_type=String")
+                .path("/data/.testKey./E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9C?create=true&data_type=String")
                 .header("cookie", "sid=testSID")
                 .reply(&with_token_filter)
                 .await;
@@ -557,7 +557,7 @@ mod tests {
                         index: None,
                         fetch_id: None,
                         create: None,
-                        create_data_type: None
+                        data_type: None
                     });
 
                     template.value == expected_value
@@ -605,7 +605,7 @@ mod tests {
                         index: None,
                         fetch_id: None,
                         create: None,
-                        create_data_type: None
+                        data_type: None
                     });
 
                     template.value == expected_value
@@ -653,7 +653,7 @@ mod tests {
                         index: None,
                         fetch_id: None,
                         create: None,
-                        create_data_type: None
+                        data_type: None
                     });
                     template.value == expected_value
                 })
@@ -700,7 +700,7 @@ mod tests {
                         index: None,
                         fetch_id: None,
                         create: None,
-                        create_data_type: None
+                        data_type: None
                     });
                     template.value == expected_value
                 })

--- a/src/routes/data/get.rs
+++ b/src/routes/data/get.rs
@@ -459,7 +459,7 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn with_token_edit_true_new_entry() {
+        async fn with_token_create() {
             let mut session = Session::new();
             session.set_cookie_value("testSID".to_owned());
             session
@@ -481,10 +481,10 @@ mod tests {
                 .withf(move |session: &Session| session.id() == expected_sid)
                 .times(1)
                 .return_once(move |_| Ok(()));
-
             mock_store
                 .expect_store_session()
-                .times(1);
+                .times(1)
+                .return_once(|_| Ok(Some("E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9C".to_string())));
             let session_store = ArcSessionStore(Arc::new(mock_store));
 
             let mut render_engine = MockRenderer::new();
@@ -524,7 +524,7 @@ mod tests {
 
             let res = warp::test::request()
                 .method("POST")
-                .path("/data/.testKey./E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9C?edit=true")
+                .path("/data/.testKey./E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9C?create=true&create_data_type=String")
                 .header("cookie", "sid=testSID")
                 .reply(&with_token_filter)
                 .await;
@@ -556,6 +556,8 @@ mod tests {
                         edit: None,
                         index: None,
                         fetch_id: None,
+                        create: None,
+                        create_data_type: None
                     });
 
                     template.value == expected_value
@@ -602,6 +604,8 @@ mod tests {
                         edit: None,
                         index: None,
                         fetch_id: None,
+                        create: None,
+                        create_data_type: None
                     });
 
                     template.value == expected_value
@@ -648,6 +652,8 @@ mod tests {
                         edit: Some(true),
                         index: None,
                         fetch_id: None,
+                        create: None,
+                        create_data_type: None
                     });
                     template.value == expected_value
                 })
@@ -693,6 +699,8 @@ mod tests {
                         edit: Some(false),
                         index: None,
                         fetch_id: None,
+                        create: None,
+                        create_data_type: None
                     });
                     template.value == expected_value
                 })

--- a/static/unsecure.handlebars
+++ b/static/unsecure.handlebars
@@ -7,7 +7,7 @@
   <body>
     <iframe id="data-iframe" src="" title="secure"></iframe>
     <script>
-      document.getElementById("data-iframe").contentWindow.location.href = "/data/{{ Unsecure.path }}/{{ Unsecure.token }}?{{ #if Unsecure.css }}css={{ Unsecure.css }}{{ /if }}{{ #if Unsecure.css and Unsecure.edit }}&{{ /if }}{{ #if Unsecure.edit }}edit={{ Unsecure.edit }}{{ /if }}{{ #if Unsecure.css and Unsecure.index }}&{{ /if }}{{ #if Unsecure.index }}index={{ Unsecure.index }}{{ /if }}{{ #if Unsecure.fetch_id }}&fetch_id={{ Unsecure.fetch_id }}{{ /if }}{{ #if Unsecure.create }}&create={{ Unsecure.create }}{{ /if }}{{ #if Unsecure.create_data_type }}&create_data_type={{ Unsecure.create_data_type }}{{ /if }}";
+      document.getElementById("data-iframe").contentWindow.location.href = "/data/{{ Unsecure.path }}/{{ Unsecure.token }}?{{ #if Unsecure.css }}css={{ Unsecure.css }}{{ /if }}{{ #if Unsecure.css and Unsecure.edit }}&{{ /if }}{{ #if Unsecure.edit }}edit={{ Unsecure.edit }}{{ /if }}{{ #if Unsecure.css and Unsecure.index }}&{{ /if }}{{ #if Unsecure.index }}index={{ Unsecure.index }}{{ /if }}{{ #if Unsecure.fetch_id }}&fetch_id={{ Unsecure.fetch_id }}{{ /if }}{{ #if Unsecure.create }}&create={{ Unsecure.create }}{{ /if }}{{ #if Unsecure.data_type }}&data_type={{ Unsecure.data_type }}{{ /if }}";
     </script>
   </body>
 </html>

--- a/static/unsecure.handlebars
+++ b/static/unsecure.handlebars
@@ -1,10 +1,13 @@
 <html>
   <head>
+	<style>
+      {{ Unsecure.css }}
+    </style>
   </head>
   <body>
     <iframe id="data-iframe" src="" title="secure"></iframe>
     <script>
-      document.getElementById("data-iframe").contentWindow.location.href = "/data/{{ Unsecure.path }}/{{ Unsecure.token }}?{{ #if Unsecure.css }}css={{ Unsecure.css }}{{ /if }}{{ #if Unsecure.css and Unsecure.edit }}&{{ /if }}{{ #if Unsecure.edit }}edit={{ Unsecure.edit }}{{ /if }}{{ #if Unsecure.css and Unsecure.index }}&{{ /if }}{{ #if Unsecure.index }}index={{ Unsecure.index }}{{ /if }}{{ #if Unsecure.fetch_id }}&fetch_id={{ Unsecure.fetch_id }}{{ /if }}";
+      document.getElementById("data-iframe").contentWindow.location.href = "/data/{{ Unsecure.path }}/{{ Unsecure.token }}?{{ #if Unsecure.css }}css={{ Unsecure.css }}{{ /if }}{{ #if Unsecure.css and Unsecure.edit }}&{{ /if }}{{ #if Unsecure.edit }}edit={{ Unsecure.edit }}{{ /if }}{{ #if Unsecure.css and Unsecure.index }}&{{ /if }}{{ #if Unsecure.index }}index={{ Unsecure.index }}{{ /if }}{{ #if Unsecure.fetch_id }}&fetch_id={{ Unsecure.fetch_id }}{{ /if }}{{ #if Unsecure.create }}&create={{ Unsecure.create }}{{ /if }}{{ #if Unsecure.create_data_type }}&create_data_type={{ Unsecure.create_data_type }}{{ /if }}";
     </script>
   </body>
 </html>


### PR DESCRIPTION
Add two new query params to the unsecure and secure GET endpoints:
- `create`: Boolean flag indicating whether a GET call is intended to create new data.  Similar to the `edit` param, however no previously existing data with a matching path is required.
- `data_type`:  A DataType Enum, which indicates the type of the new data being created. Required when `create=true`.

Also adding the query param CSS to the `unsecure.handlebars` to allow for styling of the iframe itself (mainly used to remove the iframe border, not sure if there are other use cases or if we can just hard code a no-border iframe.)