### PR TITLE
feat: Add a HTTP client w/ mutual TLS to communicate with a host website

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,6 +1194,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
+dependencies = [
+ "futures-util",
+ "hyper 0.14.10",
+ "log",
+ "rustls 0.19.1",
+ "tokio 1.8.1",
+ "tokio-rustls 0.22.0",
+ "webpki",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2189,7 +2204,7 @@ dependencies = [
  "http",
  "http-body 0.3.1",
  "hyper 0.13.10",
- "hyper-rustls",
+ "hyper-rustls 0.21.0",
  "ipnet",
  "js-sys",
  "lazy_static",
@@ -2226,6 +2241,7 @@ dependencies = [
  "http",
  "http-body 0.4.2",
  "hyper 0.14.10",
+ "hyper-rustls 0.22.1",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -2235,15 +2251,18 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite 0.2.7",
+ "rustls 0.19.1",
  "serde 1.0.126",
  "serde_json",
  "serde_urlencoded",
  "tokio 1.8.1",
  "tokio-native-tls",
+ "tokio-rustls 0.22.0",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 0.21.1",
  "winreg 0.7.0",
 ]
 
@@ -2304,6 +2323,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d1126dcf58e93cee7d098dbda643b5f92ed724f1f6a63007c1116eed6700c81"
 dependencies = [
  "base64 0.12.3",
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+dependencies = [
+ "base64 0.13.0",
  "log",
  "ring",
  "sct",
@@ -2803,6 +2835,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+dependencies = [
+ "rustls 0.19.1",
+ "tokio 1.8.1",
+ "webpki",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3282,6 +3325,15 @@ name = "webpki-roots"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f20dea7535251981a9670857150d571846545088359b28e4951d350bdaf179f"
+dependencies = [
+ "webpki",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
 dependencies = [
  "webpki",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ redact-config = "1.0.1"
 serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0.64"
 futures = "0.3.12"
-reqwest = { version = "0.11.0", features = ["json"] }
+reqwest = { version = "0.11.0", features = ["json", "rustls-tls"] }
 uuid = { version = "0.8.2", features = ["v4"] }
 async-trait = "0.1.42"
 async-session = "2.0.1"

--- a/src/error_handler.rs
+++ b/src/error_handler.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 use std::convert::Infallible;
 use warp::http::StatusCode;
 use warp::{Rejection, Reply};
+use crate::routes::error::RelayRejection;
 
 /// An API error serializable to JSON.
 #[derive(Serialize)]
@@ -31,6 +32,9 @@ pub async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> 
     } else if err.find::<BadRequestRejection>().is_some() {
         code = StatusCode::BAD_REQUEST;
         message = "BAD REQUEST";
+    } else if err.find::<RelayRejection>().is_some() {
+        code = StatusCode::INTERNAL_SERVER_ERROR;
+        message = "INTERNAL SERVER ERROR - Relay Error";
     } else {
         code = StatusCode::INTERNAL_SERVER_ERROR;
         message = "INTERNAL SERVER ERROR";

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod error_handler;
 pub mod render;
 mod routes;
 pub mod token;
+mod relayer;
 
 use crate::error_handler::handle_rejection;
 use redact_config::Configurator;
@@ -15,6 +16,7 @@ use std::collections::HashMap;
 use token::FromThreadRng;
 use warp::Filter;
 use warp_sessions::MemoryStore;
+use crate::relayer::MutualTLSRelayer;
 
 #[derive(Serialize)]
 struct Healthz {}
@@ -57,6 +59,10 @@ async fn main() {
     template_mapping.insert("secure", "./static/secure.handlebars");
     let render_engine = HandlebarsRenderer::new(template_mapping).unwrap();
 
+    // Create a relay client which supports mutual TLS
+    let relayer = MutualTLSRelayer::new(config.get_str("certificate.filepath").unwrap())
+        .unwrap();
+
     // Get storage handle
     let storage_url = config.get_str("storage.url").unwrap();
 
@@ -93,6 +99,10 @@ async fn main() {
 
     // Create a CORS filter for the insecure routes that allows any origin
     let unsecure_cors = warp::cors().allow_any_origin().allow_methods(vec!["GET"]);
+    let unsecure_cors_post = warp::cors()
+        .allow_any_origin()
+        .allow_methods(vec!["GET", "POST", "OPTIONS"])
+        .allow_headers(vec!["content-type"]);
 
     // Create a CORS filter for the secure route that allows only localhost origin
     let secure_cors = warp::cors()
@@ -107,6 +117,7 @@ async fn main() {
             render_engine.clone(),
             token_generator.clone(),
             storer.clone(),
+            relayer.clone()
         ))
         .with(secure_cors.clone());
     let get_routes = warp::get().and(
@@ -116,7 +127,7 @@ async fn main() {
             token_generator.clone(),
             storer.clone(),
         )
-        .with(unsecure_cors)
+        .with(unsecure_cors.clone())
         .or(routes::data::get::without_token(
             session_store.clone(),
             render_engine.clone(),
@@ -125,9 +136,16 @@ async fn main() {
         .with(secure_cors)),
     );
 
+    let proxy_routes = warp::any().and(
+        warp::post().and(
+            routes::proxy::post(relayer)
+        ))
+        .with(unsecure_cors_post.clone());
+
     let routes = health_route
         .or(get_routes)
         .or(post_routes)
+        .or(proxy_routes)
         .with(warp::log("routes"))
         .recover(handle_rejection);
 

--- a/src/relayer.rs
+++ b/src/relayer.rs
@@ -89,3 +89,27 @@ impl Relayer for MutualTLSRelayer {
             .map_err(|source| RelayError::RelayRequestError { source })
     }
 }
+
+#[cfg(test)]
+pub mod tests {
+    use super::{RelayError, Relayer};
+    use mockall::predicate::*;
+    use mockall::*;
+    use http::StatusCode;
+    use reqwest::Response;
+    use async_trait::async_trait;
+
+    mock! {
+    pub Relayer {}
+    impl Clone for Relayer {
+            fn clone(&self) -> Self;
+    }
+
+    #[async_trait]
+    impl Relayer for MockRelayer {
+        async fn relay(&self, path: String, relay_url: String) -> Result<StatusCode, RelayError>;
+        async fn get(&self, relay_url: String) -> Result<Response, RelayError>;
+    }
+    }
+
+}

--- a/src/relayer.rs
+++ b/src/relayer.rs
@@ -1,0 +1,91 @@
+use warp::reject::Reject;
+use http::StatusCode;
+use std::sync::Arc;
+use std::ops::Deref;
+use std::fs::File;
+use std::io::Read;
+use std::collections::HashMap;
+use thiserror::Error;
+use async_trait::async_trait;
+use reqwest::Response;
+
+#[derive(Error, Debug)]
+pub enum RelayError {
+    #[error("Failure happened during relay")]
+    RelayRequestError { source: reqwest::Error }
+}
+
+impl Reject for RelayError {}
+
+#[async_trait]
+pub trait Relayer: Clone + Send + Sync {
+    async fn relay(&self, path: String, relay_url: String) -> Result<StatusCode, RelayError>;
+    async fn get(&self, relay_url: String) -> Result<Response, RelayError>;
+}
+
+#[async_trait]
+impl<U> Relayer for Arc<U>
+    where
+        U: Relayer,
+{
+    async fn relay(&self, path: String, relay_url: String) -> Result<StatusCode, RelayError> {
+        self.deref().relay(path, relay_url).await
+    }
+
+    async fn get(&self, relay_url: String) -> Result<Response, RelayError> {
+        self.deref().get(relay_url).await
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MutualTLSRelayer {
+    pub client: reqwest::Client,
+}
+
+impl MutualTLSRelayer {
+    pub fn new(
+        pem_file_path: String,
+    ) -> Result<MutualTLSRelayer, RelayError> {
+        let mut buf = Vec::new();
+        File::open(pem_file_path)
+            .unwrap()
+            .read_to_end(&mut buf)
+            .unwrap();
+        let pkcs12 = reqwest::Identity::from_pem(&buf).unwrap();
+
+        let client = reqwest::Client::builder()
+            .identity(pkcs12)
+            .use_rustls_tls()
+            .build()
+            .unwrap();
+
+        Ok(MutualTLSRelayer { client })
+    }
+}
+
+#[async_trait]
+impl Relayer for MutualTLSRelayer {
+    async fn relay(&self, path: String, relay_url: String) -> Result<StatusCode, RelayError> {
+        let mut req_body = HashMap::new();
+        req_body.insert("path", path);
+        req_body.insert("userId", "abc".to_owned());
+
+        self.client
+            .post(relay_url)
+            .json(&req_body)
+            .send()
+            .await
+            .and_then(|response| response.error_for_status())
+            .and_then(|response| Ok(response.status()))
+            .map_err(|source| RelayError::RelayRequestError { source })
+    }
+
+    async fn get(&self, relay_url: String) -> Result<Response, RelayError> {
+        self.client
+            .get(relay_url)
+            .send()
+            .await
+            .and_then(|response| response.error_for_status())
+            .map_err(|source| RelayError::RelayRequestError { source })
+    }
+}

--- a/src/relayer.rs
+++ b/src/relayer.rs
@@ -12,7 +12,7 @@ use reqwest::Response;
 #[derive(Error, Debug)]
 pub enum RelayError {
     #[error("Failure happened during relay")]
-    RelayRequestError { source: reqwest::Error }
+    RelayRequestError { source: Option<reqwest::Error> }
 }
 
 impl Reject for RelayError {}
@@ -77,7 +77,7 @@ impl Relayer for MutualTLSRelayer {
             .await
             .and_then(|response| response.error_for_status())
             .and_then(|response| Ok(response.status()))
-            .map_err(|source| RelayError::RelayRequestError { source })
+            .map_err(|source| RelayError::RelayRequestError { source: Some(source) })
     }
 
     async fn get(&self, relay_url: String) -> Result<Response, RelayError> {
@@ -86,7 +86,7 @@ impl Relayer for MutualTLSRelayer {
             .send()
             .await
             .and_then(|response| response.error_for_status())
-            .map_err(|source| RelayError::RelayRequestError { source })
+            .map_err(|source| RelayError::RelayRequestError { source: Some(source) })
     }
 }
 

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,5 +1,6 @@
 pub mod data;
 pub mod error;
+pub(crate) mod proxy;
 
 pub use data::get::{with_token, without_token};
 pub use data::post::submit_data;

--- a/src/routes/data/post.rs
+++ b/src/routes/data/post.rs
@@ -263,15 +263,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_submit_data() {
-        #[cfg(test)]
-        // let mock_url = &mockito::server_url();
         let token = "E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9D";
         let data_path = ".testKey.";
-
-        // let m = mock("POST", "/redact/relay")
-        //     .with_status(200)
-        //     .match_body(Matcher::Json(serde_json::json!({ "path": data_path })))
-        //     .create();
 
         let mut session = Session::new();
         session.set_cookie_value("testSID".to_owned());
@@ -350,7 +343,6 @@ mod tests {
             .await;
 
         assert_eq!(res.status(), 200);
-        // m.assert();
     }
 
     #[tokio::test]

--- a/src/routes/data/post.rs
+++ b/src/routes/data/post.rs
@@ -9,10 +9,10 @@ use crate::{
 };
 use redact_crypto::{Data, HasBuilder, States, Storer, SymmetricKey, SymmetricSealer, TypeBuilder};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::convert::TryFrom;
 use warp::{Filter, Rejection, Reply};
 use warp_sessions::{CookieOptions, SameSiteCookieOption, Session, SessionStore, SessionWithStore};
+use crate::relayer::Relayer;
 
 #[derive(Deserialize, Serialize)]
 struct SubmitDataPathParams {
@@ -54,11 +54,12 @@ struct SubmitDataQueryParams {
     fetch_id: Option<String>,
 }
 
-pub fn submit_data<S: SessionStore, R: Renderer, T: TokenGenerator, H: Storer>(
+pub fn submit_data<S: SessionStore, R: Renderer, T: TokenGenerator, H: Storer, Q: Relayer>(
     session_store: S,
     render_engine: R,
     token_generator: T,
     storer: H,
+    relayer: Q
 ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
     warp::any()
         .and(warp::path!("data" / String).map(|token| SubmitDataPathParams { token }))
@@ -86,6 +87,7 @@ pub fn submit_data<S: SessionStore, R: Renderer, T: TokenGenerator, H: Storer>(
         .and(warp::any().map(move || token_generator.clone().generate_token().unwrap()))
         .and(warp::any().map(move || render_engine.clone()))
         .and(warp::any().map(move || storer.clone()))
+        .and(warp::any().map(move || relayer.clone()))
         .and_then(
             move |path_params: SubmitDataPathParams,
                   query_params: SubmitDataQueryParams,
@@ -93,14 +95,15 @@ pub fn submit_data<S: SessionStore, R: Renderer, T: TokenGenerator, H: Storer>(
                   session_with_store: SessionWithStore<S>,
                   token: String,
                   render_engine: R,
-                  storer: H| async move {
+                  storer: H,
+                  relayer: Q| async move {
                 match session_with_store.session.get("token") {
                     Some::<String>(session_token) => {
                         if session_token != path_params.token {
                             Err(warp::reject::custom(IframeTokensDoNotMatchRejection))
                         } else {
                             let key_entry = storer
-                                .get::<SymmetricKey>(".keys.default.")
+                                .get::<SymmetricKey>(".keys.default")
                                 .await
                                 .map_err(StorageErrorRejection)?;
                             let key: SymmetricKey = storer
@@ -123,22 +126,11 @@ pub fn submit_data<S: SessionStore, R: Renderer, T: TokenGenerator, H: Storer>(
                                 .await
                                 .map_err(StorageErrorRejection)?;
 
-                            match body_params.relay_url {
-                                Some(ref url) => {
-                                    let mut req_body = HashMap::new();
-                                    req_body.insert("path", body_params.path.clone());
-                                    let client = reqwest::Client::new();
-                                    client
-                                        .post(url)
-                                        .json(&req_body)
-                                        .send()
-                                        .await
-                                        .and_then(|response| response.error_for_status())
-                                        .map_err(|_| warp::reject::custom(RelayRejection))?;
-                                    Ok::<(), RelayRejection>(())
-                                }
-                                None => Ok(()),
-                            }?;
+                            if let Some(relay_url) = body_params.relay_url.clone() {
+                                relayer.relay(body_params.path.clone(), relay_url)
+                                .await
+                                .map_err(|_| warp::reject::custom(RelayRejection))?;
+                            }
 
                             Ok::<_, Rejection>((
                                 Rendered::new(

--- a/src/routes/data/post.rs
+++ b/src/routes/data/post.rs
@@ -201,6 +201,7 @@ mod tests {
     use crate::render::tests::MockRenderer;
     use crate::routes::data::post;
     use crate::token::tests::MockTokenGenerator;
+    use crate::relayer::tests::MockRelayer;
     use async_trait::async_trait;
     use mockall::predicate::*;
     use mockall::*;
@@ -217,9 +218,7 @@ mod tests {
         sync::Arc,
     };
     use warp_sessions::{ArcSessionStore, Session, SessionStore};
-
-    #[cfg(test)]
-    use mockito::{mock, Matcher};
+    use http::StatusCode;
 
     mock! {
                 pub SessionStore {}
@@ -265,14 +264,14 @@ mod tests {
     #[tokio::test]
     async fn test_submit_data() {
         #[cfg(test)]
-        let mock_url = &mockito::server_url();
+        // let mock_url = &mockito::server_url();
         let token = "E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9D";
         let data_path = ".testKey.";
 
-        let m = mock("POST", "/redact/relay")
-            .with_status(200)
-            .match_body(Matcher::Json(serde_json::json!({ "path": data_path })))
-            .create();
+        // let m = mock("POST", "/redact/relay")
+        //     .with_status(200)
+        //     .match_body(Matcher::Json(serde_json::json!({ "path": data_path })))
+        //     .create();
 
         let mut session = Session::new();
         session.set_cookie_value("testSID".to_owned());
@@ -307,7 +306,7 @@ mod tests {
             .expect_get_indexed::<SymmetricKey>()
             .times(1)
             .withf(|path, index| {
-                path == ".keys.default." && *index == Some(SymmetricKey::get_index().unwrap())
+                path == ".keys.default" && *index == Some(SymmetricKey::get_index().unwrap())
             })
             .returning(|_, _| {
                 let builder = TypeBuilder::Key(KeyBuilder::Symmetric(
@@ -329,11 +328,14 @@ mod tests {
             Ok("E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9D".to_owned())
         });
 
+        let relayer = MockRelayer::new();
+
         let submit_data = post::submit_data(
             session_store,
             Arc::new(render_engine),
             Arc::new(token_generator),
             Arc::new(storer),
+            Arc::new(relayer),
         );
 
         let res = warp::test::request()
@@ -341,13 +343,102 @@ mod tests {
             .path("/data/E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9D")
             .header("cookie", "sid=testSID")
             .body(format!(
-                "relay_url={}%2Fredact%2Frelay&path={}&value_type=string&value=qew&submit=Submit",
-                mock_url, data_path
+                "path={}&value_type=string&value=qew&submit=Submit",
+                 data_path
             ))
             .reply(&submit_data)
             .await;
 
         assert_eq!(res.status(), 200);
-        m.assert();
+        // m.assert();
+    }
+
+    #[tokio::test]
+    async fn test_submit_data_with_relay() {
+        let token = "E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9D";
+        let data_path = ".testKey.";
+
+        let mut session = Session::new();
+        session.set_cookie_value("testSID".to_owned());
+        session.insert("token", token).unwrap();
+        let expected_sid = session.id().to_owned();
+
+        let mut mock_store = MockSessionStore::new();
+        mock_store
+            .expect_load_session()
+            .with(predicate::eq("testSID".to_owned()))
+            .times(1)
+            .return_once(move |_| Ok(Some(session)));
+        mock_store
+            .expect_destroy_session()
+            .withf(move |session: &Session| session.id() == expected_sid)
+            .times(1)
+            .return_once(move |_| Ok(()));
+        mock_store
+            .expect_store_session()
+            .times(1)
+            .return_once(move |_| Ok(Some(token.to_string())));
+        let session_store = ArcSessionStore(Arc::new(mock_store));
+
+        let mut render_engine = MockRenderer::new();
+        render_engine
+            .expect_render()
+            .times(1)
+            .return_once(move |_| Ok("".to_string()));
+
+        let mut storer = MockStorer::new();
+        storer
+            .expect_get_indexed::<SymmetricKey>()
+            .times(1)
+            .withf(|path, index| {
+                path == ".keys.default" && *index == Some(SymmetricKey::get_index().unwrap())
+            })
+            .returning(|_, _| {
+                let builder = TypeBuilder::Key(KeyBuilder::Symmetric(
+                    SymmetricKeyBuilder::SodiumOxide(SodiumOxideSymmetricKeyBuilder {}),
+                ));
+                let sosk = SodiumOxideSymmetricKey::new();
+                Ok(Entry {
+                    path: ".keys.default".to_owned(),
+                    value: States::Unsealed {
+                        builder,
+                        bytes: ByteSource::Vector(VectorByteSource::new(sosk.key.as_ref())),
+                    },
+                })
+            });
+        storer.expect_create().times(1).returning(|_, _| Ok(true));
+
+        let mut token_generator = MockTokenGenerator::new();
+        token_generator.expect_generate_token().returning(|| {
+            Ok("E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9D".to_owned())
+        });
+
+        let relay_url = "http://asdfs.dsfs/relay";
+        let mut relayer = MockRelayer::new();
+        relayer.expect_relay()
+            .times(1)
+            .with(eq(data_path.to_owned()), eq(relay_url.to_owned()))
+            .return_once(move |_, _| Ok(StatusCode::OK));
+
+        let submit_data = post::submit_data(
+            session_store,
+            Arc::new(render_engine),
+            Arc::new(token_generator),
+            Arc::new(storer),
+            Arc::new(relayer),
+        );
+
+        let res = warp::test::request()
+            .method("POST")
+            .path("/data/E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9D")
+            .header("cookie", "sid=testSID")
+            .body(format!(
+                "relay_url={}&path={}&value_type=string&value=qew&submit=Submit",
+                relay_url, data_path
+            ))
+            .reply(&submit_data)
+            .await;
+
+        assert_eq!(res.status(), 200);
     }
 }

--- a/src/routes/error.rs
+++ b/src/routes/error.rs
@@ -33,3 +33,7 @@ impl Reject for CryptoErrorRejection {}
 #[derive(Debug)]
 pub struct RelayRejection;
 impl Reject for RelayRejection {}
+
+#[derive(Debug)]
+pub struct ProxyRejection(pub reqwest::Error);
+impl Reject for ProxyRejection {}

--- a/src/routes/proxy.rs
+++ b/src/routes/proxy.rs
@@ -1,0 +1,44 @@
+use warp::{Filter, Rejection, Reply, http::Response};
+use crate::relayer::Relayer;
+use crate::routes::error::{RelayRejection, ProxyRejection};
+use serde::{Deserialize, Serialize};
+use reqwest;
+use warp::http::HeaderValue;
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+struct ProxyBodyParams {
+    host_url: String
+}
+
+pub fn post<Q: Relayer>(
+    relayer: Q
+) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+    warp::any()
+        .and(warp::path!("proxy"))
+        .and(warp::filters::body::json::<ProxyBodyParams>())
+        .and(warp::any().map(move || relayer.clone()))
+        .and_then(
+            move |
+                body_params: ProxyBodyParams,
+                relayer: Q
+            | async move {
+                relayer.get(body_params.host_url)
+                    .await
+                    .map_err(|_| warp::reject::custom(RelayRejection))
+            }
+        )
+        .and_then(
+            move |response: reqwest::Response| async move {
+                Ok::<_, Rejection>(Response::builder()
+                    .status(response.status())
+                    .header("Content-Type", response.headers()
+                        .get("Content-Type")
+                        .unwrap_or(&HeaderValue::from_static("")))
+                    .body(
+                        response.text()
+                            .await
+                            .map_err(ProxyRejection)?
+                    ))
+            }
+        )
+}

--- a/src/routes/proxy.rs
+++ b/src/routes/proxy.rs
@@ -42,3 +42,73 @@ pub fn post<Q: Relayer>(
             }
         )
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::routes::proxy;
+    use crate::relayer::{tests::MockRelayer, RelayError::RelayRequestError};
+    use mockall::predicate::*;
+    use std::sync::Arc;
+    use warp::http::HeaderValue;
+
+    #[tokio::test]
+    async fn test_post() {
+        let host_url = "http://host.com/proxy/session/whatever";
+
+        let expected_response = http::response::Builder::new()
+            .header("Content-Type", "text/html")
+            .status(200)
+            .body("brr".to_owned())
+            .unwrap();
+
+        let mut relayer = MockRelayer::new();
+        relayer.expect_get()
+            .times(1)
+            .with(eq(host_url.to_owned()))
+            .return_once(move |_| Ok(reqwest::Response::from(expected_response)));
+
+        let proxy = proxy::post(
+            Arc::new(relayer),
+        );
+
+        let res = warp::test::request()
+            .method("POST")
+            .path("/proxy")
+            .body(format!("{{\"host_url\":\"{}\"}}", host_url))
+            .header("Content-Type", "application/json")
+            .reply(&proxy)
+            .await;
+
+        assert_eq!(res.status(), 200);
+        assert_eq!(res.body(), "brr");
+        assert_eq!(
+            res.headers().get("Content-Type"),
+            Some(&HeaderValue::from_static("text/html"))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_post_relay_request_error() {
+        let host_url = "http://host.com/proxy/session/whatever";
+
+        let mut relayer = MockRelayer::new();
+        relayer.expect_get()
+            .times(1)
+            .with(eq(host_url.to_owned()))
+            .return_once(move |_| Err(RelayRequestError{source: None}));
+
+        let proxy = proxy::post(
+            Arc::new(relayer),
+        );
+
+        let res = warp::test::request()
+            .method("POST")
+            .path("/proxy")
+            .body(format!("{{\"host_url\":\"{}\"}}", host_url))
+            .header("Content-Type", "application/json")
+            .reply(&proxy)
+            .await;
+
+        assert_eq!(res.status(), 500);
+    }
+}


### PR DESCRIPTION
Creating a "Relayer", which is responsible for communicating with a host website on behalf of a Redact user (for situations where the UI cannot, since it does not know who the user is).  A self-signed certificate is used to identify the client to the host.

The Relayer has two methods:
- Relay: Send information regarding updates that a user has made to their data that is of interest to the host
- Get: make a GET request to the host, and simply return the response.  This is currently used for Feed, in which the user makes a request to the API endpoint to retrieve a JWT token, which can then be used to identify the user via the host website.