### PR TITLE
Image upload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2184,7 +2184,7 @@ dependencies = [
 [[package]]
 name = "redact-crypto"
 version = "0.1.0"
-source = "git+https://github.com/pauwels-labs/redact-crypto.git?rev=29fbd9a122092940534f928d8b69f995ab154114#29fbd9a122092940534f928d8b69f995ab154114"
+source = "git+https://github.com/pauwels-labs/redact-crypto.git?rev=8c04c54c7fde95c13c8461863dea27a8ce63e160#8c04c54c7fde95c13c8461863dea27a8ce63e160"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,6 +667,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1315,6 +1321,15 @@ name = "ipnet"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
+
+[[package]]
+name = "itertools"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -2149,6 +2164,7 @@ dependencies = [
  "handlebars",
  "http",
  "hyper 0.14.10",
+ "itertools",
  "mockall",
  "mockito",
  "mongodb",
@@ -2163,6 +2179,7 @@ dependencies = [
  "serde_json",
  "sha2 0.9.5",
  "sodiumoxide",
+ "strum",
  "thiserror",
  "tokio 1.8.1",
  "url",
@@ -2184,7 +2201,7 @@ dependencies = [
 [[package]]
 name = "redact-crypto"
 version = "0.1.0"
-source = "git+https://github.com/pauwels-labs/redact-crypto.git?rev=8c04c54c7fde95c13c8461863dea27a8ce63e160#8c04c54c7fde95c13c8461863dea27a8ce63e160"
+source = "git+https://github.com/pauwels-labs/redact-crypto.git?rev=2b29a1c92b687d2c8b190b8241160a08222a6037#2b29a1c92b687d2c8b190b8241160a08222a6037"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -2199,6 +2216,7 @@ dependencies = [
  "serde 1.0.126",
  "serde_json",
  "sodiumoxide",
+ "strum",
  "uuid",
 ]
 
@@ -2687,6 +2705,27 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf86bbcfd1fa9670b7a129f64fc0c9fcbbfe4f1bc4210e9e98fe71ffc12cde2"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d06aaeeee809dbc59eb4556183dd927df67db1540de5be8d3ec0b6636358a5ec"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "subtle"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2144,6 +2144,7 @@ dependencies = [
  "async-trait",
  "base64 0.13.0",
  "bson",
+ "bytes 1.0.1",
  "futures",
  "handlebars",
  "http",
@@ -2183,7 +2184,7 @@ dependencies = [
 [[package]]
 name = "redact-crypto"
 version = "0.1.0"
-source = "git+https://github.com/pauwels-labs/redact-crypto.git?rev=12b54f4cffe7019759152b06ef89afb4c807c9c9#12b54f4cffe7019759152b06ef89afb4c807c9c9"
+source = "git+https://github.com/pauwels-labs/redact-crypto.git?rev=14fa0afc08f43890b781206d4d3437fb92da6c9e#14fa0afc08f43890b781206d4d3437fb92da6c9e"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2184,13 +2184,14 @@ dependencies = [
 [[package]]
 name = "redact-crypto"
 version = "0.1.0"
-source = "git+https://github.com/pauwels-labs/redact-crypto.git?rev=14fa0afc08f43890b781206d4d3437fb92da6c9e#14fa0afc08f43890b781206d4d3437fb92da6c9e"
+source = "git+https://github.com/pauwels-labs/redact-crypto.git?rev=29fbd9a122092940534f928d8b69f995ab154114#29fbd9a122092940534f928d8b69f995ab154114"
 dependencies = [
  "async-recursion",
  "async-trait",
  "base64 0.13.0",
  "futures",
  "hex",
+ "mockall",
  "mongodb",
  "once_cell",
  "reqwest 0.11.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ warp-sessions = "1.0.13"
 base64 = "0.13.0"
 sodiumoxide = "0.2.6"
 http = "0.2.4"
-redact-crypto = { git = "https://github.com/pauwels-labs/redact-crypto.git", rev = "29fbd9a122092940534f928d8b69f995ab154114" }
+redact-crypto = { git = "https://github.com/pauwels-labs/redact-crypto.git", rev = "8c04c54c7fde95c13c8461863dea27a8ce63e160" }
 bson = "1.2.2"
 regex = "1.5.4"
 percent-encoding = "2.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ warp-sessions = "1.0.13"
 base64 = "0.13.0"
 sodiumoxide = "0.2.6"
 http = "0.2.4"
-redact-crypto = { git = "https://github.com/pauwels-labs/redact-crypto.git", rev = "76fe189c10770cab8aff0c65ccbf0c3422805fb5" }
+redact-crypto = { git = "https://github.com/pauwels-labs/redact-crypto.git", rev = "14fa0afc08f43890b781206d4d3437fb92da6c9e" }
 bson = "1.2.2"
 regex = "1.5.4"
 percent-encoding = "2.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,13 +44,15 @@ warp-sessions = "1.0.13"
 base64 = "0.13.0"
 sodiumoxide = "0.2.6"
 http = "0.2.4"
-redact-crypto = { git = "https://github.com/pauwels-labs/redact-crypto.git", rev = "8c04c54c7fde95c13c8461863dea27a8ce63e160" }
+redact-crypto = { git = "https://github.com/pauwels-labs/redact-crypto.git", rev = "2b29a1c92b687d2c8b190b8241160a08222a6037" }
 bson = "1.2.2"
 regex = "1.5.4"
 percent-encoding = "2.1.0"
 url = "2.2.2"
 addr = "0.14.0"
 bytes = "1.0.1"
+itertools = "0.10.1"
+strum = { version = "0.21"}
 
 [dev-dependencies]
 mockall = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,12 +44,13 @@ warp-sessions = "1.0.13"
 base64 = "0.13.0"
 sodiumoxide = "0.2.6"
 http = "0.2.4"
-redact-crypto = { git = "https://github.com/pauwels-labs/redact-crypto.git", rev = "12b54f4cffe7019759152b06ef89afb4c807c9c9" }
+redact-crypto = { git = "https://github.com/pauwels-labs/redact-crypto.git", rev = "76fe189c10770cab8aff0c65ccbf0c3422805fb5" }
 bson = "1.2.2"
 regex = "1.5.4"
 percent-encoding = "2.1.0"
 url = "2.2.2"
 addr = "0.14.0"
+bytes = "1.0.1"
 
 [dev-dependencies]
 mockall = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ warp-sessions = "1.0.13"
 base64 = "0.13.0"
 sodiumoxide = "0.2.6"
 http = "0.2.4"
-redact-crypto = { git = "https://github.com/pauwels-labs/redact-crypto.git", rev = "14fa0afc08f43890b781206d4d3437fb92da6c9e" }
+redact-crypto = { git = "https://github.com/pauwels-labs/redact-crypto.git", rev = "29fbd9a122092940534f928d8b69f995ab154114" }
 bson = "1.2.2"
 regex = "1.5.4"
 percent-encoding = "2.1.0"

--- a/README.md
+++ b/README.md
@@ -21,43 +21,7 @@ The unsecure URL is the one placed in the third-party website's iframe, it requi
 3. `cargo r`
 
 ## Usage
-- Unsecure fetch data route. This URL requires no tokens and would be provided to an iframe. It returns a page with another iframe to an internal route.
-	- `GET /data/<path>?css=<string>&edit=<bool>&data_type=<string>&relay_url=<string>`
-	- `<path>` is a jsonpath-style string prepended and appended by a period, e.g. `.profile.firstName.`
-	- `css` is a URL-encoded CSS block meant to style the displayed data. The generated HTML can be seen [here](https://github.com/pauwels-labs/redact-client/tree/main/static/secure.handlebars).
-	- `edit` should be `true` or `false` depending on if the value should be displayed in an editable input field.
-	- `data_type` specifies the type of data to expect; this is particularly useful when creating new data that does not yet have a type. The value can be one of:
-		- `Bool`
-		- `U64`
-		- `I64`
-		- `F64`
-		- `String`
-		- `Media`
-			- A binary file which will be rendered in the browser upon retrieval. Currently supported file types are:
-				- `image/jpeg`
-	- `relay_url` provides a handle to contact with feedback on stored user input. This would typically be a URL controlled by the host of the Redact-enabled website and used for internal bookkeeping.
-	
-- Secure fetch data route. This route is a CSRF protection process to ensure the client and only the client can possibly be requesting this data.
-	- `GET /data/<path>/<token>?css=<string>&edit=<bool>&data_type=<string>&relay_url=<string>`
-	- `<path>` is a jsonpath-style string prepended and appended by a period, e.g. `.profile.firstName.`
-	- `<token>` is the secure token returned by the unsecure request
-	- `css` is a URL-encoded CSS block meant to style the displayed data. The generated HTML can be seen [here](https://github.com/pauwels-labs/redact-client/tree/main/static/secure.handlebars).
-	- `edit` should be `true` or `false` depending on if the value should be displayed in an editable input field.
-	- `data_type` specifies the type of data to expect; this is particularly useful when creating new data that does not yet have a type. The value can be one of:
-		- `Bool`
-		- `U64`
-		- `I64`
-		- `F64`
-		- `String`
-		- `Media`
-	- `relay_url` provides a handle to contact with feedback on stored user input. This would typically be a URL controlled by the host of the Redact-enabled website and used for internal bookkeeping.
-	- There's also a `Cookie` header implied here which must contain a session ID for the session containing the same token as the one in the query parameters.
-	
-- Secure submit data route. This is identical to the previous to the secure fetch route but as a POST in order to submit a modification to the data store. This will also only be called internally.
-	- `POST /data/<token>?css=<string>&edit=<bool>`
-	- `<token>` is the secure token returned by the unsecure request
-	- `css` is a URL-encoded CSS block meant to style the displayed data. The generated HTML can be seen [here](https://github.com/pauwels-labs/redact-client/tree/main/static/secure.handlebars).
-	- `edit` should be `true` or `false` depending on if the value should be displayed in an editable input field.
+Refer to the [Redact Client Docs](https://docs.redact.ws/en/latest/client.html) for API documentation.
 
 ## Test
 To run unit tests:

--- a/README.md
+++ b/README.md
@@ -22,32 +22,34 @@ The unsecure URL is the one placed in the third-party website's iframe, it requi
 
 ## Usage
 - Unsecure fetch data route. This URL requires no tokens and would be provided to an iframe. It returns a page with another iframe to an internal route.
-	- `GET /data/<path>?css=<string>&edit=<bool>&create=<bool>&data_type=<string>&relay_url=<string>`
+	- `GET /data/<path>?css=<string>&edit=<bool>&data_type=<string>&relay_url=<string>`
 	- `<path>` is a jsonpath-style string prepended and appended by a period, e.g. `.profile.firstName.`
 	- `css` is a URL-encoded CSS block meant to style the displayed data. The generated HTML can be seen [here](https://github.com/pauwels-labs/redact-client/tree/main/static/secure.handlebars).
 	- `edit` should be `true` or `false` depending on if the value should be displayed in an editable input field.
-	- `create` should be `true` or `false` depending on if the value should be created if it is missing
 	- `data_type` specifies the type of data to expect; this is particularly useful when creating new data that does not yet have a type. The value can be one of:
 		- `Bool`
 		- `U64`
 		- `I64`
 		- `F64`
 		- `String`
+		- `Media`
+			- A binary file which will be rendered in the browser upon retrieval. Currently supported file types are:
+				- `image/jpeg`
 	- `relay_url` provides a handle to contact with feedback on stored user input. This would typically be a URL controlled by the host of the Redact-enabled website and used for internal bookkeeping.
 	
 - Secure fetch data route. This route is a CSRF protection process to ensure the client and only the client can possibly be requesting this data.
-	- `GET /data/<path>/<token>?css=<string>&edit=<bool>&create=<bool>&data_type=<string>&relay_url=<string>`
+	- `GET /data/<path>/<token>?css=<string>&edit=<bool>&data_type=<string>&relay_url=<string>`
 	- `<path>` is a jsonpath-style string prepended and appended by a period, e.g. `.profile.firstName.`
 	- `<token>` is the secure token returned by the unsecure request
 	- `css` is a URL-encoded CSS block meant to style the displayed data. The generated HTML can be seen [here](https://github.com/pauwels-labs/redact-client/tree/main/static/secure.handlebars).
 	- `edit` should be `true` or `false` depending on if the value should be displayed in an editable input field.
-	- `create` should be `true` or `false` depending on if the value should be created if it is missing
 	- `data_type` specifies the type of data to expect; this is particularly useful when creating new data that does not yet have a type. The value can be one of:
 		- `Bool`
 		- `U64`
 		- `I64`
 		- `F64`
 		- `String`
+		- `Media`
 	- `relay_url` provides a handle to contact with feedback on stored user input. This would typically be a URL controlled by the host of the Redact-enabled website and used for internal bookkeeping.
 	- There's also a `Cookie` header implied here which must contain a session ID for the session containing the same token as the one in the query parameters.
 	

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,6 +107,14 @@ async fn main() {
             storer.clone(),
             relayer.clone(),
         ))
+        .with(secure_cors.clone())
+        .or(routes::data::post::submit_data_multipart(
+            session_store.clone(),
+            render_engine.clone(),
+            token_generator.clone(),
+            storer.clone(),
+            relayer.clone(),
+        ))
         .with(secure_cors.clone());
     let get_routes = warp::get().and(
         routes::data::get::with_token(

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,14 +107,6 @@ async fn main() {
             storer.clone(),
             relayer.clone(),
         ))
-        .with(secure_cors.clone())
-        .or(routes::data::post::submit_data_multipart(
-            session_store.clone(),
-            render_engine.clone(),
-            token_generator.clone(),
-            storer.clone(),
-            relayer.clone(),
-        ))
         .with(secure_cors.clone());
     let get_routes = warp::get().and(
         routes::data::get::with_token(

--- a/src/render.rs
+++ b/src/render.rs
@@ -152,6 +152,10 @@ fn data_input(
                 s
             ))
         }
+        Data::Binary(b) => {
+            out.write("<input type=\"hidden\" name=\"value_type\" value=\"binary\">")?;
+            out.write("<input type=\"file\" class=\"file\" name=\"value\" autofocus>")
+        }
     }
     .map_err(|e| e.into())
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -6,6 +6,8 @@ use std::ops::Deref;
 use std::{collections::HashMap, sync::Arc};
 use thiserror::Error;
 use warp::{reject::Reject, Reply};
+use itertools::free::join;
+use strum::IntoEnumIterator;
 
 #[derive(Error, Debug)]
 pub enum RenderError {
@@ -104,7 +106,7 @@ fn data_display(
                         BinaryType::VideoMP4 | BinaryType::VideoMPEG => {
                             out.write(
                                 &format!(
-                                    "<video controls id=\"data\"><source src=\"data:{};base64, {}\"></video>",
+                                    "<video controls id=\"data-video\"><source src=\"data:{};base64, {}\"></video>",
                                     binary.binary_type.to_string(),
                                     binary.binary
                                 )
@@ -183,7 +185,10 @@ fn data_input(
         }
         Data::Binary(_) => {
             out.write("<input type=\"hidden\" name=\"value_type\" value=\"media\">")?;
-            out.write("<input type=\"file\" class=\"file\" name=\"value\" autofocus>")
+            out.write(&format!(
+                "<input type=\"file\" class=\"file\" name=\"value\" accept=\"{}\"autofocus>",
+                &join(BinaryType::iter(), &",")
+            ))
         }
     }
     .map_err(|e| e.into())

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,6 +1,6 @@
-use handlebars::{Context, Handlebars, Helper, Output, RenderContext, RenderError as HandlebarsRenderError, TemplateError as HandlebarsTemplateError, HelperDef, HelperResult, Renderable};
+use handlebars::{Context, Handlebars, Helper, Output, RenderContext, RenderError as HandlebarsRenderError, TemplateError as HandlebarsTemplateError};
 use redact_crypto::Data;
-use serde::{Serialize, Deserialize};
+use serde::{Serialize};
 use std::convert::From;
 use std::ops::Deref;
 use std::{collections::HashMap, sync::Arc};

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,5 +1,5 @@
 use handlebars::{Context, Handlebars, Helper, Output, RenderContext, RenderError as HandlebarsRenderError, TemplateError as HandlebarsTemplateError};
-use redact_crypto::Data;
+use redact_crypto::{Data, BinaryType};
 use serde::{Serialize};
 use std::convert::From;
 use std::ops::Deref;
@@ -99,7 +99,26 @@ fn data_display(
     match value {
         Data::Binary(b) => {
             match b {
-                Some(binary) => out.write(&format!("<img id=\"data\" src=\"data:{};base64, {}\"/>", binary.binary_type.to_string(), binary.binary)).map_err(|e| e.into()),
+                Some(binary) => {
+                    match binary.binary_type {
+                        BinaryType::VideoMP4 | BinaryType::VideoMPEG => {
+                            out.write(
+                                &format!(
+                                    "<video controls id=\"data\"><source src=\"data:{};base64, {}\"></video>",
+                                    binary.binary_type.to_string(),
+                                    binary.binary
+                                )
+                            ).map_err(|e| e.into())
+                        },
+                        _ => out.write(
+                            &format!(
+                                "<img id=\"data\" src=\"data:{};base64, {}\"/>",
+                                binary.binary_type.to_string(),
+                                binary.binary
+                            )
+                        ).map_err(|e| e.into()),
+                    }
+                }
                 None => out.write("").map_err(|e| e.into()),
             }
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -163,7 +163,7 @@ fn data_input(
             ))
         }
         Data::Binary(_) => {
-            out.write("<input type=\"hidden\" name=\"value_type\" value=\"binary\">")?;
+            out.write("<input type=\"hidden\" name=\"value_type\" value=\"media\">")?;
             out.write("<input type=\"file\" class=\"file\" name=\"value\" autofocus>")
         }
     }

--- a/src/routes/data/get.rs
+++ b/src/routes/data/get.rs
@@ -327,6 +327,7 @@ mod tests {
     use mockall::*;
     use mongodb::bson::Document;
     use redact_crypto::{CryptoError, Entry, EntryPath, HasBuilder, State, Storer, StorableType};
+    use crate::token::tests::MockTokenGenerator;
 
     mock! {
     pub Storer {}
@@ -369,6 +370,7 @@ mod tests {
             sync::Arc,
         };
         use warp_sessions::{ArcSessionStore, Session, SessionStore};
+        use crate::routes::data::get::tests::setup_mock_token_helper;
 
         mock! {
                     pub SessionStore {}
@@ -412,27 +414,10 @@ mod tests {
 
         #[tokio::test]
         async fn with_token_with_no_query_params() {
-            let mut session = Session::new();
-            session.set_cookie_value("testSID".to_owned());
-            session
-                .insert(
-                    "token",
-                    "E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9C",
-                )
-                .unwrap();
+            let session = setup_session_helper("E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9D");
             let expected_sid = session.id().to_owned();
 
-            let mut mock_store = MockSessionStore::new();
-            mock_store
-                .expect_load_session()
-                .with(predicate::eq("testSID".to_owned()))
-                .times(1)
-                .return_once(move |_| Ok(Some(session)));
-            mock_store
-                .expect_destroy_session()
-                .withf(move |session: &Session| session.id() == expected_sid)
-                .times(1)
-                .return_once(move |_| Ok(()));
+            let mock_store = setup_mock_session_store_helper(expected_sid, session);
             let session_store = ArcSessionStore(Arc::new(mock_store));
 
             let mut render_engine = MockRenderer::new();
@@ -459,16 +444,9 @@ mod tests {
                 .times(1)
                 .return_once(move |_| Ok("".to_string()));
 
-            let mut token_generator = MockTokenGenerator::new();
-            token_generator
-                .expect_generate_token()
-                .times(1)
-                .returning(|| {
-                    Ok(
-                        "E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9D"
-                            .to_owned(),
-                    )
-                });
+            let token_generator = setup_mock_token_helper(
+                "E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9D".to_owned(),
+            );
 
             let mut storer = MockStorer::new();
             storer
@@ -496,7 +474,7 @@ mod tests {
             );
 
             let res = warp::test::request()
-                    .path("/data/.testKey./E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9C")
+                    .path("/data/.testKey./E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9D")
                     .header("cookie", "sid=testSID")
                     .reply(&with_token_filter)
                     .await;
@@ -505,27 +483,9 @@ mod tests {
 
         #[tokio::test]
         async fn with_token_with_data_type_binary() {
-            let mut session = Session::new();
-            session.set_cookie_value("testSID".to_owned());
-            session
-                .insert(
-                    "token",
-                    "E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9C",
-                )
-                .unwrap();
+            let session = setup_session_helper("E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9C");
             let expected_sid = session.id().to_owned();
-
-            let mut mock_store = MockSessionStore::new();
-            mock_store
-                .expect_load_session()
-                .with(predicate::eq("testSID".to_owned()))
-                .times(1)
-                .return_once(move |_| Ok(Some(session)));
-            mock_store
-                .expect_destroy_session()
-                .withf(move |session: &Session| session.id() == expected_sid)
-                .times(1)
-                .return_once(move |_| Ok(()));
+            let mock_store = setup_mock_session_store_helper(expected_sid, session);
             let session_store = ArcSessionStore(Arc::new(mock_store));
 
             let mut render_engine = MockRenderer::new();
@@ -552,16 +512,9 @@ mod tests {
                 .times(1)
                 .return_once(move |_| Ok("".to_string()));
 
-            let mut token_generator = MockTokenGenerator::new();
-            token_generator
-                .expect_generate_token()
-                .times(1)
-                .returning(|| {
-                    Ok(
-                        "E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9D"
-                            .to_owned(),
-                    )
-                });
+            let token_generator = setup_mock_token_helper(
+                "E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9D".to_owned(),
+            );
 
             let mut storer = MockStorer::new();
             storer
@@ -593,27 +546,10 @@ mod tests {
 
         #[tokio::test]
         async fn with_token_with_existing_binary_data() {
-            let mut session = Session::new();
-            session.set_cookie_value("testSID".to_owned());
-            session
-                .insert(
-                    "token",
-                    "E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9C",
-                )
-                .unwrap();
+            let session = setup_session_helper("E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9C");
             let expected_sid = session.id().to_owned();
 
-            let mut mock_store = MockSessionStore::new();
-            mock_store
-                .expect_load_session()
-                .with(predicate::eq("testSID".to_owned()))
-                .times(1)
-                .return_once(move |_| Ok(Some(session)));
-            mock_store
-                .expect_destroy_session()
-                .withf(move |session: &Session| session.id() == expected_sid)
-                .times(1)
-                .return_once(move |_| Ok(()));
+            let mock_store = setup_mock_session_store_helper(expected_sid, session);
             let session_store = ArcSessionStore(Arc::new(mock_store));
 
             let mut render_engine = MockRenderer::new();
@@ -627,7 +563,7 @@ mod tests {
                         }))),
                         path: Some(".testKey.".to_owned()),
                         token: Some(
-                            "E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9D"
+                            "E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9C"
                                 .to_owned(),
                         ),
                         css: None,
@@ -643,16 +579,9 @@ mod tests {
                 .times(1)
                 .return_once(move |_| Ok("".to_string()));
 
-            let mut token_generator = MockTokenGenerator::new();
-            token_generator
-                .expect_generate_token()
-                .times(1)
-                .returning(|| {
-                    Ok(
-                        "E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9D"
-                            .to_owned(),
-                    )
-                });
+            let token_generator = setup_mock_token_helper(
+                "E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9C".to_owned(),
+            );
 
             let mut storer = MockStorer::new();
             storer
@@ -689,27 +618,10 @@ mod tests {
 
         #[tokio::test]
         async fn with_token_create() {
-            let mut session = Session::new();
-            session.set_cookie_value("testSID".to_owned());
-            session
-                .insert(
-                    "token",
-                    "E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9C",
-                )
-                .unwrap();
+            let session = setup_session_helper("E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9C");
             let expected_sid = session.id().to_owned();
 
-            let mut mock_store = MockSessionStore::new();
-            mock_store
-                .expect_load_session()
-                .with(predicate::eq("testSID".to_owned()))
-                .times(1)
-                .return_once(move |_| Ok(Some(session)));
-            mock_store
-                .expect_destroy_session()
-                .withf(move |session: &Session| session.id() == expected_sid)
-                .times(1)
-                .return_once(move |_| Ok(()));
+            let mut mock_store = setup_mock_session_store_helper(expected_sid, session);
             mock_store
                 .expect_store_session()
                 .times(1)
@@ -722,16 +634,9 @@ mod tests {
                 .times(1)
                 .return_once(move |_| Ok("".to_string()));
 
-            let mut token_generator = MockTokenGenerator::new();
-            token_generator
-                .expect_generate_token()
-                .times(1)
-                .returning(|| {
-                    Ok(
-                        "E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9D"
-                            .to_owned(),
-                    )
-                });
+            let token_generator = setup_mock_token_helper(
+                "E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9C".to_owned(),
+            );
 
             let mut storer = MockStorer::new();
             storer
@@ -760,6 +665,32 @@ mod tests {
                 .await;
             assert_eq!(res.status(), 200);
         }
+
+        // Helper method for creating a Session with a given token
+        fn setup_session_helper(token: &str) -> Session {
+            let mut session = Session::new();
+            session.set_cookie_value("testSID".to_owned());
+            session
+                .insert("token", token)
+                .unwrap();
+            session
+        }
+
+        // Helper method to setup the mock session store and the load & destroy session method mocks
+        fn setup_mock_session_store_helper(expected_sid: String, session: Session) -> MockSessionStore {
+            let mut mock_store = MockSessionStore::new();
+            mock_store
+                .expect_load_session()
+                .with(predicate::eq("testSID".to_owned()))
+                .times(1)
+                .return_once(move |_| Ok(Some(session)));
+            mock_store
+                .expect_destroy_session()
+                .withf(move |session: &Session| session.id() == expected_sid)
+                .times(1)
+                .return_once(move |_| Ok(()));
+            mock_store
+        }
     }
 
     mod without_token {
@@ -770,6 +701,7 @@ mod tests {
         use crate::token::tests::MockTokenGenerator;
         use std::sync::Arc;
         use warp_sessions::MemoryStore;
+        use crate::routes::data::get::tests::setup_mock_token_helper;
 
         #[tokio::test]
         async fn without_token_with_no_query_params() {
@@ -794,17 +726,9 @@ mod tests {
                 })
                 .times(1)
                 .return_once(move |_| Ok("".to_string()));
-
-            let mut token_generator = MockTokenGenerator::new();
-            token_generator
-                .expect_generate_token()
-                .times(1)
-                .returning(|| {
-                    Ok(
-                        "E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9C"
-                            .to_owned(),
-                    )
-                });
+            let token_generator = setup_mock_token_helper(
+                "E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9C".to_owned()
+            );
 
             let without_token_filter = get::without_token(
                 session_store,
@@ -842,17 +766,9 @@ mod tests {
                 })
                 .times(1)
                 .return_once(move |_| Ok("".to_string()));
-
-            let mut token_generator = MockTokenGenerator::new();
-            token_generator
-                .expect_generate_token()
-                .times(1)
-                .returning(|| {
-                    Ok(
-                        "E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9C"
-                            .to_owned(),
-                    )
-                });
+            let token_generator = setup_mock_token_helper(
+                "E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9C".to_owned(),
+            );
 
             let without_token_filter = get::without_token(
                 session_store,
@@ -889,17 +805,7 @@ mod tests {
                 })
                 .times(1)
                 .return_once(move |_| Ok("".to_string()));
-
-            let mut token_generator = MockTokenGenerator::new();
-            token_generator
-                .expect_generate_token()
-                .times(1)
-                .returning(|| {
-                    Ok(
-                        "E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9C"
-                            .to_owned(),
-                    )
-                });
+            let token_generator = setup_mock_token_helper("E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9C".to_owned());
 
             let without_token_filter = get::without_token(
                 session_store,
@@ -937,16 +843,7 @@ mod tests {
                 .times(1)
                 .return_once(move |_| Ok("".to_string()));
 
-            let mut token_generator = MockTokenGenerator::new();
-            token_generator
-                .expect_generate_token()
-                .times(1)
-                .returning(|| {
-                    Ok(
-                        "E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9C"
-                            .to_owned(),
-                    )
-                });
+            let token_generator = setup_mock_token_helper("E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9C".to_owned());
 
             let without_token_filter = get::without_token(
                 session_store,
@@ -986,16 +883,7 @@ mod tests {
                 .times(1)
                 .return_once(move |_| Ok("".to_string()));
 
-            let mut token_generator = MockTokenGenerator::new();
-            token_generator
-                .expect_generate_token()
-                .times(1)
-                .returning(|| {
-                    Ok(
-                        "E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9C"
-                            .to_owned(),
-                    )
-                });
+            let token_generator = setup_mock_token_helper("E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9C".to_owned());
 
             let without_token_filter = get::without_token(
                 session_store,
@@ -1069,5 +957,15 @@ mod tests {
         }
 
 
+    }
+
+    // Helper method which sets up a mock TokenGenerator which returns a given token on generate_token()
+    fn setup_mock_token_helper(token: String) -> MockTokenGenerator {
+        let mut token_generator = MockTokenGenerator::new();
+        token_generator
+            .expect_generate_token()
+            .times(1)
+            .returning(move || Ok(token.to_owned()));
+        token_generator
     }
 }

--- a/src/routes/data/get.rs
+++ b/src/routes/data/get.rs
@@ -451,9 +451,11 @@ mod tests {
                         ),
                         css: None,
                         edit: None,
+                        data_type: None,
                         relay_url: None,
                         js_message: None,
                         js_height_msg_prefix: None,
+                        is_binary_data: false
                     });
                     template.value == expected_value
                 })

--- a/src/routes/data/get.rs
+++ b/src/routes/data/get.rs
@@ -361,7 +361,7 @@ mod tests {
         use async_trait::async_trait;
         use mockall::predicate::*;
         use mockall::*;
-        use redact_crypto::{ByteSource, CryptoError, Data, DataBuilder, Entry, HasIndex, MongoStorerError, State, StringDataBuilder, TypeBuilder, VectorByteSource, BinaryDataBuilder};
+        use redact_crypto::{ByteSource, CryptoError, Data, DataBuilder, Entry, HasIndex, MongoStorerError, State, StringDataBuilder, TypeBuilder, VectorByteSource, BinaryDataBuilder, BinaryData, BinaryType};
         use serde::Serialize;
 
         use std::{
@@ -500,6 +500,190 @@ mod tests {
                     .header("cookie", "sid=testSID")
                     .reply(&with_token_filter)
                     .await;
+            assert_eq!(res.status(), 200);
+        }
+
+        #[tokio::test]
+        async fn with_token_with_data_type_binary() {
+            let mut session = Session::new();
+            session.set_cookie_value("testSID".to_owned());
+            session
+                .insert(
+                    "token",
+                    "E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9C",
+                )
+                .unwrap();
+            let expected_sid = session.id().to_owned();
+
+            let mut mock_store = MockSessionStore::new();
+            mock_store
+                .expect_load_session()
+                .with(predicate::eq("testSID".to_owned()))
+                .times(1)
+                .return_once(move |_| Ok(Some(session)));
+            mock_store
+                .expect_destroy_session()
+                .withf(move |session: &Session| session.id() == expected_sid)
+                .times(1)
+                .return_once(move |_| Ok(()));
+            let session_store = ArcSessionStore(Arc::new(mock_store));
+
+            let mut render_engine = MockRenderer::new();
+            render_engine
+                .expect_render()
+                .withf(move |template: &RenderTemplate| {
+                    let expected_value = TemplateValues::Secure(SecureTemplateValues {
+                        data: Some(Data::Binary(None)),
+                        path: Some(".testKey.".to_owned()),
+                        token: Some(
+                            "E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9D"
+                                .to_owned(),
+                        ),
+                        css: None,
+                        edit: None,
+                        data_type: Some("Media".to_owned()),
+                        relay_url: None,
+                        js_message: None,
+                        js_height_msg_prefix: None,
+                        is_binary_data: true
+                    });
+                    template.value == expected_value
+                })
+                .times(1)
+                .return_once(move |_| Ok("".to_string()));
+
+            let mut token_generator = MockTokenGenerator::new();
+            token_generator
+                .expect_generate_token()
+                .times(1)
+                .returning(|| {
+                    Ok(
+                        "E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9D"
+                            .to_owned(),
+                    )
+                });
+
+            let mut storer = MockStorer::new();
+            storer
+                .expect_get_indexed::<Data>()
+                .times(1)
+                .withf(|path, index| {
+                    path == ".testKey." && *index == Some(Data::get_index().unwrap())
+                })
+                .returning(|_, _| {
+                    Err(CryptoError::NotFound {
+                        source: Box::new(CryptoError::NotDowncastable)
+                    })
+                });
+
+            let with_token_filter = get::with_token(
+                session_store,
+                Arc::new(render_engine),
+                Arc::new(token_generator),
+                Arc::new(storer),
+            );
+
+            let res = warp::test::request()
+                .path("/data/.testKey./E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9C?data_type=Media")
+                .header("cookie", "sid=testSID")
+                .reply(&with_token_filter)
+                .await;
+            assert_eq!(res.status(), 200);
+        }
+
+        #[tokio::test]
+        async fn with_token_with_existing_binary_data() {
+            let mut session = Session::new();
+            session.set_cookie_value("testSID".to_owned());
+            session
+                .insert(
+                    "token",
+                    "E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9C",
+                )
+                .unwrap();
+            let expected_sid = session.id().to_owned();
+
+            let mut mock_store = MockSessionStore::new();
+            mock_store
+                .expect_load_session()
+                .with(predicate::eq("testSID".to_owned()))
+                .times(1)
+                .return_once(move |_| Ok(Some(session)));
+            mock_store
+                .expect_destroy_session()
+                .withf(move |session: &Session| session.id() == expected_sid)
+                .times(1)
+                .return_once(move |_| Ok(()));
+            let session_store = ArcSessionStore(Arc::new(mock_store));
+
+            let mut render_engine = MockRenderer::new();
+            render_engine
+                .expect_render()
+                .withf(move |template: &RenderTemplate| {
+                    let expected_value = TemplateValues::Secure(SecureTemplateValues {
+                        data: Some(Data::Binary(Some(BinaryData {
+                            binary_type: BinaryType::ImageJPEG,
+                            binary: "abc".to_owned()
+                        }))),
+                        path: Some(".testKey.".to_owned()),
+                        token: Some(
+                            "E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9D"
+                                .to_owned(),
+                        ),
+                        css: None,
+                        edit: None,
+                        data_type: None,
+                        relay_url: None,
+                        js_message: None,
+                        js_height_msg_prefix: None,
+                        is_binary_data: true
+                    });
+                    template.value == expected_value
+                })
+                .times(1)
+                .return_once(move |_| Ok("".to_string()));
+
+            let mut token_generator = MockTokenGenerator::new();
+            token_generator
+                .expect_generate_token()
+                .times(1)
+                .returning(|| {
+                    Ok(
+                        "E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9D"
+                            .to_owned(),
+                    )
+                });
+
+            let mut storer = MockStorer::new();
+            storer
+                .expect_get_indexed::<Data>()
+                .times(1)
+                .withf(|path, index| {
+                    path == ".testKey." && *index == Some(Data::get_index().unwrap())
+                })
+                .returning(|_, _| {
+                    let builder = TypeBuilder::Data(DataBuilder::Binary(BinaryDataBuilder {}));
+                    Ok(Entry::new(
+                        ".testKey.".to_owned(),
+                        builder,
+                        State::Unsealed {
+                            bytes: ByteSource::Vector(VectorByteSource::new(Some(b"{\"binary\":\"abc\",\"binary_type\":\"ImageJPEG\"}"))),
+                        }
+                    ))
+                });
+
+            let with_token_filter = get::with_token(
+                session_store,
+                Arc::new(render_engine),
+                Arc::new(token_generator),
+                Arc::new(storer),
+            );
+
+            let res = warp::test::request()
+                .path("/data/.testKey./E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9C")
+                .header("cookie", "sid=testSID")
+                .reply(&with_token_filter)
+                .await;
             assert_eq!(res.status(), 200);
         }
 

--- a/src/routes/data/get.rs
+++ b/src/routes/data/get.rs
@@ -529,6 +529,10 @@ mod tests {
                 .withf(move |session: &Session| session.id() == expected_sid)
                 .times(1)
                 .return_once(move |_| Ok(()));
+            mock_store
+                .expect_store_session()
+                .times(1)
+                .return_once(move |_| Ok(Some("E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9C".to_owned())));
             let session_store = ArcSessionStore(Arc::new(mock_store));
 
             let mut render_engine = MockRenderer::new();

--- a/src/routes/data/get.rs
+++ b/src/routes/data/get.rs
@@ -151,7 +151,7 @@ pub fn without_token<S: SessionStore, R: Renderer, T: TokenGenerator>(
         .and_then(warp_sessions::reply::with_session)
 }
 
-pub fn with_token<S: SessionStore, R: Renderer, T: TokenGenerator, H: Storer>(
+pub fn with_token<S: SessionStore, R: Renderer, T: TokenGenerator, H: Storer + Clone>(
     session_store: S,
     render_engine: R,
     token_generator: T,
@@ -361,10 +361,7 @@ mod tests {
         use async_trait::async_trait;
         use mockall::predicate::*;
         use mockall::*;
-        use redact_crypto::{
-            ByteSource, CryptoError, Data, DataBuilder, Entry, HasIndex, MongoStorerError, State,
-            StringDataBuilder, TypeBuilder, VectorByteSource,
-        };
+        use redact_crypto::{ByteSource, CryptoError, Data, DataBuilder, Entry, HasIndex, MongoStorerError, State, StringDataBuilder, TypeBuilder, VectorByteSource, BinaryDataBuilder};
         use serde::Serialize;
 
         use std::{
@@ -886,5 +883,7 @@ mod tests {
                 .await;
             assert_eq!(res.status(), 500);
         }
+
+
     }
 }

--- a/src/routes/data/get.rs
+++ b/src/routes/data/get.rs
@@ -217,7 +217,7 @@ pub fn with_token<S: SessionStore, R: Renderer, T: TokenGenerator, H: Storer>(
                                 "u64" => Data::U64(0),
                                 "i64" => Data::I64(0),
                                 "f64" => Data::F64(0.0),
-                                "binary" => Data::Binary(None),
+                                "media" => Data::Binary(None),
                                 _ => Data::String("".to_owned()),
                             }
                         } else {

--- a/src/routes/data/get.rs
+++ b/src/routes/data/get.rs
@@ -225,6 +225,12 @@ pub fn with_token<S: SessionStore, R: Renderer, T: TokenGenerator, H: Storer>(
                         }
                     }
                 };
+
+                let is_binary_data = match data {
+                    Data::Binary(_) => true,
+                    _ => query_params.data_type == Some("binary".to_owned())
+                };
+
                 let reply = Rendered::new(
                     render_engine,
                     RenderTemplate {
@@ -238,7 +244,8 @@ pub fn with_token<S: SessionStore, R: Renderer, T: TokenGenerator, H: Storer>(
                             data_type: query_params.data_type,
                             relay_url: query_params.relay_url,
                             js_message: query_params.js_message,
-                            js_height_msg_prefix: query_params.js_height_msg_prefix
+                            js_height_msg_prefix: query_params.js_height_msg_prefix,
+                            is_binary_data: is_binary_data
                         }),
                     },
                 )?;

--- a/src/routes/data/get.rs
+++ b/src/routes/data/get.rs
@@ -206,12 +206,13 @@ pub fn with_token<S: SessionStore, R: Renderer, T: TokenGenerator, H: Storer>(
                         .await
                         .map_err(CryptoErrorRejection)?,
                     None => {
-                        if let Some(data_type) = query_params.data_type {
+                        if let Some(data_type) = query_params.data_type.clone() {
                             match data_type.to_ascii_lowercase().as_ref() {
                                 "bool" => Data::Bool(false),
                                 "u64" => Data::U64(0),
                                 "i64" => Data::I64(0),
                                 "f64" => Data::F64(0.0),
+                                "binary" => Data::Binary(None),
                                 _ => Data::String("".to_owned()),
                             }
                         } else {
@@ -229,6 +230,7 @@ pub fn with_token<S: SessionStore, R: Renderer, T: TokenGenerator, H: Storer>(
                             token: Some(token.clone()),
                             css: query_params.css,
                             edit: query_params.edit,
+                            data_type: query_params.data_type,
                             relay_url: query_params.relay_url,
                             js_message: query_params.js_message,
                         }),

--- a/src/routes/data/get.rs
+++ b/src/routes/data/get.rs
@@ -228,7 +228,7 @@ pub fn with_token<S: SessionStore, R: Renderer, T: TokenGenerator, H: Storer>(
 
                 let is_binary_data = match data {
                     Data::Binary(_) => true,
-                    _ => query_params.data_type == Some("binary".to_owned())
+                    _ => query_params.data_type == Some("media".to_owned())
                 };
 
                 let reply = Rendered::new(
@@ -569,7 +569,7 @@ mod tests {
             );
 
             let res = warp::test::request()
-                .path("/data/.testKey./E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9C?create=true&data_type=String")
+                .path("/data/.testKey./E0AE2C1C9AA2DB85DFA2FF6B4AAC7A5E51FFDAA3948BECEC353561D513E59A9C?edit=true&data_type=String")
                 .header("cookie", "sid=testSID")
                 .reply(&with_token_filter)
                 .await;

--- a/src/routes/data/post.rs
+++ b/src/routes/data/post.rs
@@ -58,7 +58,7 @@ struct SubmitDataQueryParams {
     js_height_msg_prefix: Option<String>
 }
 
-pub fn submit_data<S: SessionStore, R: Renderer, T: TokenGenerator, H: Storer, Q: Relayer>(
+pub fn submit_data<S: SessionStore, R: Renderer, T: TokenGenerator, H: Storer + Clone, Q: Relayer>(
     session_store: S,
     render_engine: R,
     token_generator: T,
@@ -158,7 +158,7 @@ pub fn submit_data<S: SessionStore, R: Renderer, T: TokenGenerator, H: Storer, Q
                                 .await
                                 .map_err(CryptoErrorRejection)?;
                             let key_algo = key_entry
-                                .to_byte_algorithm(None)
+                                .to_symmetric_byte_algorithm(None)
                                 .await
                                 .map_err(CryptoErrorRejection)?;
                             let data_clone = data.clone();

--- a/src/routes/data/post.rs
+++ b/src/routes/data/post.rs
@@ -74,7 +74,8 @@ pub fn submit_data<S: SessionStore, R: Renderer, T: TokenGenerator, H: Storer + 
                 Ok::<_, Rejection>((Data::try_from(body)?, path))
             },)
             .or(warp::filters::multipart::form()
-                .and_then(move |form: FormData| async {
+                .max_length(1024 * 1024 * 16) // 16 MB
+                .and_then(|form: FormData| async {
                     let binary_type: Option<BinaryType> = None;
                     let binary_data: Option<String> = None;
                     let path: Option<String> = None;

--- a/src/routes/data/post.rs
+++ b/src/routes/data/post.rs
@@ -142,6 +142,7 @@ pub fn submit_data<S: SessionStore, R: Renderer, T: TokenGenerator, H: Storer, Q
                                             relay_url: query_params.relay_url,
                                             js_message: query_params.js_message,
                                             js_height_msg_prefix: query_params.js_height_msg_prefix,
+                                            is_binary_data: false
                                         }),
                                     },
                                 )?,
@@ -307,6 +308,11 @@ pub fn submit_data_multipart<S: SessionStore, R: Renderer, T: TokenGenerator, H:
                                     .map_err(|_| warp::reject::custom(RelayRejection))?;
                             }
 
+                            let is_binary_data = match data {
+                                Data::Binary(_) => true,
+                                _ => query_params.data_type == Some("binary".to_owned())
+                            };
+
                             Ok::<_, Rejection>((
                                 Rendered::new(
                                     render_engine,
@@ -322,6 +328,7 @@ pub fn submit_data_multipart<S: SessionStore, R: Renderer, T: TokenGenerator, H:
                                             relay_url: query_params.relay_url,
                                             js_message: query_params.js_message,
                                             js_height_msg_prefix: query_params.js_height_msg_prefix,
+                                            is_binary_data: is_binary_data
                                         }),
                                     },
                                 )?,

--- a/static/secure.handlebars
+++ b/static/secure.handlebars
@@ -6,7 +6,7 @@
   </head>
   <body>
     {{ #if Secure.edit }}
-	<form id="form" action="/data/{{ Secure.token }}?css={{ Secure.css }}&edit={{ Secure.edit }}{{ #if Secure.js_height_msg_prefix }}&js_height_msg_prefix={{ Secure.js_height_msg_prefix }}{{ /if }}{{ #if Secure.js_message }}&js_message={{ Secure.js_message }}{{ /if }}{{ #if Secure.relay_url }}&relay_url={{ Secure.relay_url }}{{ /if }}" method="POST" {{ form_type Secure.data_type }}>
+<form id="form" action="/data/{{ Secure.token }}?css={{ Secure.css }}&edit={{ Secure.edit }}{{ #if Secure.js_height_msg_prefix }}&js_height_msg_prefix={{ Secure.js_height_msg_prefix }}{{ /if }}{{ #if Secure.js_message }}&js_message={{ Secure.js_message }}{{ /if }}{{ #if Secure.relay_url }}&relay_url={{ Secure.relay_url }}{{ /if }}" method="POST" {{ #if Secure.is_binary_data }}enctype="multipart/form-data"{{/if}}>
       {{ #if Secure.relay_url }}
       <input type="hidden" value="{{ Secure.relay_url }}" id="relay_url" name="relay_url">
       {{ /if }}
@@ -34,7 +34,7 @@
 	  {{ #if Secure.edit }}
 		document.getElementById("form").addEventListener('submit', functSubmit);
 
-		{{#if (eq "binary" Secure.data_type)}}
+		{{#if Secure.is_binary_data}}
 			document.getElementById("form").enctype = 'multipart/form-data';
 			function functSubmit(event) {
 				const formTarget = event.target;

--- a/static/secure.handlebars
+++ b/static/secure.handlebars
@@ -21,14 +21,24 @@
         {{ data_display Secure.data }}
     {{ /if }}
 
-
 	<script>
-	{{ #if Secure.js_height_msg_prefix }}
-		var clientHeight = document.getElementById('data').clientHeight;
-		var message = atob("{{ Secure.js_height_msg_prefix }}") + clientHeight;
-		window.parent.postMessage(btoa(message), "*");
-	{{/if}}
 
+
+	{{ #if Secure.js_height_msg_prefix }}
+		var elem = document.getElementById('data');
+		var video_elem = document.getElementById('data-video');
+
+		if (elem != null) {
+		  elem.addEventListener("load", function() {
+			var message = atob("{{ Secure.js_height_msg_prefix }}") + elem.clientHeight;
+			window.parent.postMessage(btoa(message), "*");
+		  });
+		} else if (video_elem != null) {
+		  var message_video = atob("{{ Secure.js_height_msg_prefix }}") + video_elem.clientHeight;
+		  window.parent.postMessage(btoa(message_video), "*");
+		  console.log(message_video);
+		}
+	{{/if}}
 
 	{{ #if Secure.js_message }}
 	  {{ #if Secure.edit }}
@@ -55,9 +65,6 @@
 			const formTarget = event.target;
 			var form = new FormData(formTarget);
 
-			for(const name in data) {
-				form.append(name, data[name]);
-			}
 			var formBody = [];
 			for (let [name, value] of form) {
 			  var encodedKey = encodeURIComponent(name);

--- a/static/secure.handlebars
+++ b/static/secure.handlebars
@@ -6,7 +6,7 @@
   </head>
   <body>
     {{ #if Secure.edit }}
-    <form id="form" action="/data/{{ Secure.token }}?css={{ Secure.css }}&edit={{ Secure.edit }}" method="POST">
+    <form id="form" action="/data/{{ Secure.token }}?css={{ Secure.css }}&edit={{ Secure.edit }}&data_type={{ Secure.data_type }}" method="POST" {{ form_type Secure.data_type }}>
       {{ #if Secure.relay_url }}
       <input type="hidden" value="{{ Secure.relay_url }}" id="relay_url" name="relay_url">
       {{ /if }}
@@ -18,43 +18,63 @@
       <input type="submit" value="Submit" name="submit" id="submit">
     </form>
     {{ else }}
-      <p>
         {{ data_display Secure.data }}
-      </p>
     {{ /if }}
 
 
 	<script>
 	{{ #if Secure.js_message }}
 	  {{ #if Secure.edit }}
-      document.getElementById("form").addEventListener('submit', functSubmit);
-      function functSubmit(event) {
-		const formTarget = event.target;
-		var form = new FormData(formTarget);
+		document.getElementById("form").addEventListener('submit', functSubmit);
 
-		var formBody = [];
-		for (let [name, value] of form) {
-		  var encodedKey = encodeURIComponent(name);
-		  var encodedValue = encodeURIComponent(value);
-		  formBody.push(encodedKey + "=" + encodedValue);
-		}
-		formBody = formBody.join("&");
+		{{#if (eq "binary" Secure.data_type)}}
+			document.getElementById("form").enctype = 'multipart/form-data';
+			function functSubmit(event) {
+				const formTarget = event.target;
+				var form = new FormData(formTarget);
+				fetch(formTarget.action, {
+					method: formTarget.method,
+					body: form
+				})
+				.then((res) => {
+				  window.parent.postMessage("{{ Secure.js_message }}", "*");
+				  return res.text();
+				});
+				// Prevent the default form submit
+				event.preventDefault();
+			  }
+		{{ else }}
+		  function functSubmit(event) {
+			const formTarget = event.target;
+			var form = new FormData(formTarget);
 
-		fetch(formTarget.action, {
-		  method: formTarget.method,
-		  headers: {
-    		'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
-  		  },
-  		  body: formBody
-		})
-		.then((res) => {
-		  	window.parent.postMessage("{{ Secure.js_message }}", "*");
-		  return res.text();
-		});
+			for(const name in data) {
+				form.append(name, data[name]);
+			}
+			var formBody = [];
+			for (let [name, value] of form) {
+			  var encodedKey = encodeURIComponent(name);
+			  var encodedValue = encodeURIComponent(value);
+			  formBody.push(encodedKey + "=" + encodedValue);
+			}
+			formBody = formBody.join("&");
 
-		// Prevent the default form submit
-		event.preventDefault();
-	  }
+			fetch(formTarget.action, {
+			  method: formTarget.method,
+			  headers: {
+				'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
+			  },
+			  body: formBody
+			})
+			.then((res) => {
+				window.parent.postMessage("{{ Secure.js_message }}", "*");
+			  return res.text();
+			});
+
+			// Prevent the default form submit
+			event.preventDefault();
+		  }
+		{{/if}}
 	  {{/if}}
 	{{/if}}
 


### PR DESCRIPTION
This PR adds support for JPEG image data.  The client responds to an editable media GET request (`GET /data/.path.?edit=true&data_type=media`) with a file upload form.  When submitted, the file binary and mime-type are stored in the Storage as Binary data.  When retrieved, the image is rendered in an HTML `<img>` tag, with the binary type and base64 encoded binary as the `src`.