### PR TITLE
Verification Codes & Colors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,10 @@ async fn main() {
     // Determine port to listen on
     let port = get_port(&config);
 
+    // Values used for verifying Redact editable fields
+    let code_phrase=config.get_str("code.phrase").unwrap();
+    let code_color=config.get_str("code.color").unwrap();
+
     // Load HTML templates
     let mut template_mapping = HashMap::new();
     template_mapping.insert("unsecure", "./static/unsecure.handlebars");
@@ -107,6 +111,8 @@ async fn main() {
             token_generator.clone(),
             storer_shared.clone(),
             relayer.clone(),
+            code_phrase.clone(),
+            code_color.clone()
         ))
         .with(secure_cors.clone());
     let get_routes = warp::get().and(
@@ -115,6 +121,8 @@ async fn main() {
             render_engine.clone(),
             token_generator.clone(),
             storer_shared.clone(),
+            code_phrase,
+            code_color
         )
         .with(unsecure_cors.clone())
         .or(routes::data::get::without_token(

--- a/src/render.rs
+++ b/src/render.rs
@@ -48,7 +48,9 @@ pub struct SecureTemplateValues {
     pub relay_url: Option<String>,
     pub js_message: Option<String>,
     pub js_height_msg_prefix: Option<String>,
-    pub is_binary_data: bool
+    pub is_binary_data: bool,
+    pub code_phrase: String,
+    pub code_color: String
 }
 
 impl From<HandlebarsTemplateError> for RenderError {

--- a/src/routes/data/post.rs
+++ b/src/routes/data/post.rs
@@ -64,6 +64,8 @@ pub fn submit_data<S: SessionStore, R: Renderer, T: TokenGenerator, H: Storer + 
     token_generator: T,
     storer: H,
     relayer: Q,
+    code_phrase: String,
+    code_color: String
 ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
     warp::any()
         .and(warp::path!("data" / String).map(|token| SubmitDataPathParams { token }))
@@ -141,6 +143,8 @@ pub fn submit_data<S: SessionStore, R: Renderer, T: TokenGenerator, H: Storer + 
         .and(warp::any().map(move || render_engine.clone()))
         .and(warp::any().map(move || storer.clone()))
         .and(warp::any().map(move || relayer.clone()))
+        .and(warp::any().map(move || code_phrase.clone()))
+        .and(warp::any().map(move || code_color.clone()))
         .and_then(
             move |path_params: SubmitDataPathParams,
                   query_params: SubmitDataQueryParams,
@@ -149,7 +153,9 @@ pub fn submit_data<S: SessionStore, R: Renderer, T: TokenGenerator, H: Storer + 
                   token: String,
                   render_engine: R,
                   storer: H,
-                  relayer: Q| async move {
+                  relayer: Q,
+                  code_phrase,
+                  code_color| async move {
                 match session_with_store.session.get("token") {
                     Some::<String>(session_token) => {
                         if session_token != path_params.token {
@@ -191,7 +197,9 @@ pub fn submit_data<S: SessionStore, R: Renderer, T: TokenGenerator, H: Storer + 
                                             relay_url: query_params.relay_url,
                                             js_message: query_params.js_message,
                                             js_height_msg_prefix: query_params.js_height_msg_prefix,
-                                            is_binary_data: false
+                                            is_binary_data: false,
+                                            code_phrase,
+                                            code_color
                                         }),
                                     },
                                 )?,

--- a/static/secure.handlebars
+++ b/static/secure.handlebars
@@ -4,7 +4,7 @@
       {{ Secure.css }}
     </style>
   </head>
-  <body style="border: blue;">
+  <body {{ #if Secure.edit }} style="border: 2px solid #{{Secure.code_color}};" {{ /if }}>
     {{ #if Secure.edit }}
 <form id="form" action="/data/{{ Secure.token }}?css={{ Secure.css }}&edit={{ Secure.edit }}{{ #if Secure.js_height_msg_prefix }}&js_height_msg_prefix={{ Secure.js_height_msg_prefix }}{{ /if }}{{ #if Secure.js_message }}&js_message={{ Secure.js_message }}{{ /if }}{{ #if Secure.relay_url }}&relay_url={{ Secure.relay_url }}{{ /if }}" method="POST" {{ #if Secure.is_binary_data }}enctype="multipart/form-data"{{/if}}>
       {{ #if Secure.relay_url }}
@@ -15,7 +15,9 @@
 	  {{ /if }}
       <input type="hidden" value="{{ Secure.path }}" id="path" name="path">
       {{ data_input Secure.data }}
-      <input type="submit" value="Submit" name="submit" id="submit">
+      <button type="submit" name="submit" id="submit">
+		  Submit<span style="font-size: 8px;color:grey;">🔒{{Secure.code_phrase}}</span>
+	  </button>
     </form>
     {{ else }}
         {{ data_display Secure.data }}

--- a/static/secure.handlebars
+++ b/static/secure.handlebars
@@ -4,7 +4,7 @@
       {{ Secure.css }}
     </style>
   </head>
-  <body>
+  <body style="border: blue;">
     {{ #if Secure.edit }}
 <form id="form" action="/data/{{ Secure.token }}?css={{ Secure.css }}&edit={{ Secure.edit }}{{ #if Secure.js_height_msg_prefix }}&js_height_msg_prefix={{ Secure.js_height_msg_prefix }}{{ /if }}{{ #if Secure.js_message }}&js_message={{ Secure.js_message }}{{ /if }}{{ #if Secure.relay_url }}&relay_url={{ Secure.relay_url }}{{ /if }}" method="POST" {{ #if Secure.is_binary_data }}enctype="multipart/form-data"{{/if}}>
       {{ #if Secure.relay_url }}


### PR DESCRIPTION
The idea here is to add visual verification for a Redact user to ensure that a input field is truly Redacted, meaning that the input field and submit button was provided by the Client and therefore the form input will only be submitted to the client.
<img width="813" alt="Screen Shot 2021-08-18 at 3 32 08 PM" src="https://user-images.githubusercontent.com/11092330/129917711-822babc4-164c-47ed-8572-5af8a549e9f9.png">

There are two components, the "code color" and the "code phrase".  The code color is used to identify the borders of a Redact input field.  The code phrase is used to verify that a submit button is generated by the Client.  Both values are configured on the Client.
