### PR TITLE
fix: change cookie path for secure routes

### DIFF
--- a/src/routes/secure/data.rs
+++ b/src/routes/secure/data.rs
@@ -66,7 +66,7 @@ pub fn get<R: Renderer + Clone + Send + 'static, H: Storer, T: TokenGenerator>(
                 };
 
                 let new_path: Option<String> = match query.edit {
-                    Some(true) => Some(format!("/secure/data/{}/{}", &path, &new_token)),
+                    Some(true) => Some(format!("/secure/data/{}", &new_token)),
                     _ => None,
                 };
 


### PR DESCRIPTION
- In the organize routes PR, the cookie path was incorrectly set
  to be /secure/data/<data path>/<token>
- The HTML form submission path, however, was defined to be
  /secure/data/<token>, with the <data path> provided as a body
  parameter
- This fixes the issue so that both cookie path and form path are
  now /secure/data/<token>