### PR TITLE
feat: add directory creation for crypto material

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2462,7 +2462,7 @@ dependencies = [
 [[package]]
 name = "redact-crypto"
 version = "0.1.0"
-source = "git+https://github.com/pauwels-labs/redact-crypto.git?rev=3645919b4ab4add14b1a2551afed12e1624d510c#3645919b4ab4add14b1a2551afed12e1624d510c"
+source = "git+https://github.com/pauwels-labs/redact-crypto.git?rev=a0d7a857a2605c8bec0fcbdcc42aa7426afe0ea7#a0d7a857a2605c8bec0fcbdcc42aa7426afe0ea7"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ warp-sessions = "1.0.13"
 base64 = "0.13.0"
 sodiumoxide = "0.2.6"
 http = "0.2.4"
-redact-crypto = { git = "https://github.com/pauwels-labs/redact-crypto.git", rev = "3645919b4ab4add14b1a2551afed12e1624d510c" }
+redact-crypto = { git = "https://github.com/pauwels-labs/redact-crypto.git", rev = "a0d7a857a2605c8bec0fcbdcc42aa7426afe0ea7" }
 bson = "1.2.2"
 regex = "1.5.4"
 percent-encoding = "2.1.0"


### PR DESCRIPTION
Currently, when starting the app, errors always occur due to missing directories.

This PR creates directory structures requested in the filepaths used for generation of the crypto material.

The redact-crypto update pulls a directory-creation change for the FsByteSource.